### PR TITLE
fix checkbox styles

### DIFF
--- a/src/Toggle/index.js
+++ b/src/Toggle/index.js
@@ -74,20 +74,30 @@ export default withStyles(theme => ({
   root: {
     display: 'inline-flex',
     alignItems: 'center',
-    // cursor: disabled ? 'not-allowed' : 'pointer',
-    // opacity: disabled ? '0.65' : '1',
+
+    '&:focus': {
+      outline: 'none',
+    },
+
+    '&:disabled': {
+      cursor: 'not-allowed',
+    },
   },
   toggle: {
     position: 'relative',
     display: 'inline-block',
     width: '44px',
     height: '40px',
+
     borderRadius: '2px',
-    padding: '10px',
+    padding: '8px 10px 12px 10px',
     flexShrink: '0',
     overflow: 'hidden',
+    fill: theme.colors.gray500,
+    '$root:focus & svg': {
+      boxShadow: theme.globalBoxShadow,
+    },
 
-    // on-click expanding-circle animation shenanigans
     ':after': {
       content: '""',
       display: 'block',
@@ -99,16 +109,13 @@ export default withStyles(theme => ({
       left: '0',
       pointerEvents: 'none',
       backgroundColor: theme.colors.primary,
-      // transform: checked ? 'scale(1, 1)' : 'scale(0, 0)',
-      // opacity: checked ? '0' : '0.4',
-      // transitionProperty: 'transform, opacity',
-      // transitionTimingFunction: 'ease-out',
-      // transitionDuration: checked ? '600ms' : '0s',
     },
   },
   label: {
+    color: theme.colors.gray500,
+    fontFamily: 'inherit',
+    fontWeight: '400',
     fontSize: '16px',
-    fontWeight: '500',
-    paddingRight: '12px', // extra hitbox padding
+    lineHeight: '20px',
   },
 }))(Toggle);


### PR DESCRIPTION
Not 100% sold on the box-shadow, but it's inarguably better than before

# Checkbox before
![screen shot 2018-05-14 at 1 19 31 pm](https://user-images.githubusercontent.com/1302526/40021411-988449ac-5779-11e8-80c8-74a3f500f486.png)

# Checkbox after
![screen shot 2018-05-14 at 1 18 53 pm](https://user-images.githubusercontent.com/1302526/40021421-9d9a784e-5779-11e8-9e58-17f04ef303a0.png)

# Radio before
![screen shot 2018-05-14 at 1 19 42 pm](https://user-images.githubusercontent.com/1302526/40021447-b396b46e-5779-11e8-8c1d-adf559c4e064.png)


# Radio after
![screen shot 2018-05-14 at 1 19 05 pm](https://user-images.githubusercontent.com/1302526/40021454-b9b16998-5779-11e8-925f-5580160c7dee.png)
