### PR TITLE
Typography - Added to docs/Heading & gutterBottom additions

### DIFF
--- a/demo/src/docs/Typography.js
+++ b/demo/src/docs/Typography.js
@@ -7,18 +7,24 @@ const TypographyExample = () => (
   <Paper>
     <Typography type="title">{`<Typography />`}</Typography>
     <hr />
-    <Typography type="title">Title</Typography>
-    <br />
-    <Typography type="heading2">Heading2</Typography>
-    <br />
-    <Typography type="heading3">Heading3</Typography>
-    <br />
-    <Typography type="heading4">Heading4</Typography>
-    <br />
-    <Typography type="heading5">Heading5</Typography>
-    <br />
-    <Typography type="heading6">Heading6</Typography>
-    <br />
+    <Typography type="title" gutterBottom>
+      Title
+    </Typography>
+    <Typography type="heading2" gutterBottom>
+      Heading2
+    </Typography>
+    <Typography type="heading3" gutterBottom>
+      Heading3
+    </Typography>
+    <Typography type="heading4" gutterBottom>
+      Heading4
+    </Typography>
+    <Typography type="heading5" gutterBottom>
+      Heading5
+    </Typography>
+    <Typography type="heading6" gutterBottom>
+      Heading6
+    </Typography>
     <Typography type="body">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt
       vulputate mi, sit amet elementum arcu rutrum sit amet. Vivamus in semper

--- a/demo/src/docs/Typography.js
+++ b/demo/src/docs/Typography.js
@@ -1,0 +1,38 @@
+import React from "react";
+
+import Paper from "elevate-ui/Paper";
+import Typography from "elevate-ui/Typography";
+
+const TypographyExample = () => (
+  <Paper>
+    <Typography type="title">{`<Typography />`}</Typography>
+    <hr />
+    <Typography type="title">Title</Typography>
+    <br />
+    <Typography type="heading2">Heading2</Typography>
+    <br />
+    <Typography type="heading3">Heading3</Typography>
+    <br />
+    <Typography type="heading4">Heading4</Typography>
+    <br />
+    <Typography type="heading5">Heading5</Typography>
+    <br />
+    <Typography type="heading6">Heading6</Typography>
+    <br />
+    <Typography type="body">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec tincidunt
+      vulputate mi, sit amet elementum arcu rutrum sit amet. Vivamus in semper
+      lorem. Nullam et nibh semper, pellentesque est quis, mattis elit. Nullam
+      tellus lectus, placerat sit amet arcu eu, placerat condimentum elit.
+      Quisque sit amet neque laoreet turpis euismod hendrerit. Curabitur sed
+      rutrum metus, ut aliquet arcu. Sed a arcu quis nisi sagittis commodo quis
+      ut leo. Aliquam interdum massa augue, a ornare ante mattis consectetur.
+      Fusce tempus, quam vel fermentum rutrum, velit risus hendrerit sapien, at
+      ornare quam nibh a nulla. Suspendisse dictum venenatis augue, in ultricies
+      augue dignissim porttitor. Nullam dictum consequat elit eu dictum. Sed
+      imperdiet est ac tempus facilisis.
+    </Typography>
+  </Paper>
+);
+
+export default TypographyExample;

--- a/demo/src/layout/Main.js
+++ b/demo/src/layout/Main.js
@@ -21,6 +21,7 @@ const RadioGroups = Loadable({
 const Datetimes = Loadable({ loader: () => import("../docs/Datetimes") });
 const Buttons = Loadable({ loader: () => import("../docs/Buttons") });
 const Alerts = Loadable({ loader: () => import("../docs/Alerts") });
+const Typography = Loadable({ loader: () => import("../docs/Typography") });
 const Tables = Loadable({ loader: () => import("../docs/Tables") });
 const Icons = Loadable({ loader: () => import("../docs/Icons") });
 const SignupForm = Loadable({ loader: () => import("../docs/SignupForm") });
@@ -41,6 +42,7 @@ const Main = ({ classes }) => (
       <Route path="/radio-group" component={RadioGroups} />
       <Route path="/datetime" component={Datetimes} />
       <Route path="/button" component={Buttons} />
+      <Route path="/typography" component={Typography} />
       <Route path="/alert" component={Alerts} />
       <Route path="/table" component={Tables} />
       <Route path="/icon" component={Icons} />

--- a/demo/src/layout/Sidebar.js
+++ b/demo/src/layout/Sidebar.js
@@ -129,6 +129,13 @@ const Sidebar = ({ classes }) => {
         <NavLink
           activeClassName={classes.active}
           className={classes.item}
+          to="/typography"
+        >
+          Typography
+        </NavLink>
+        <NavLink
+          activeClassName={classes.active}
+          className={classes.item}
           to="/alert"
         >
           Alert

--- a/src/Typography/index.js
+++ b/src/Typography/index.js
@@ -8,12 +8,24 @@ type Props = {
   className: string,
   component: string,
   theme: Object,
-  type: "title" | "body",
+  type:
+    | "title"
+    | "body"
+    | "heading2"
+    | "heading3"
+    | "heading4"
+    | "heading5"
+    | "heading6",
 };
 
 const typeElementMap = {
   title: "h1",
   body: "p",
+  heading2: "h2",
+  heading3: "h3",
+  heading4: "h4",
+  heading5: "h5",
+  heading6: "h6",
 };
 
 const Typography = ({
@@ -43,6 +55,36 @@ export default withStyles((theme) => ({
   title: {
     fontSize: "36px",
     lineHeight: "48px",
+    fontWeight: "600",
+    color: theme.colors.gray800,
+  },
+  heading2: {
+    fontSize: "32px",
+    lineHeight: "44px",
+    fontWeight: "600",
+    color: theme.colors.gray800,
+  },
+  heading3: {
+    fontSize: "28px",
+    lineHeight: "40px",
+    fontWeight: "600",
+    color: theme.colors.gray800,
+  },
+  heading4: {
+    fontSize: "24px",
+    lineHeight: "36px",
+    fontWeight: "600",
+    color: theme.colors.gray800,
+  },
+  heading5: {
+    fontSize: "20px",
+    lineHeight: "32px",
+    fontWeight: "600",
+    color: theme.colors.gray800,
+  },
+  heading6: {
+    fontSize: "18px",
+    lineHeight: "30px",
     fontWeight: "600",
     color: theme.colors.gray800,
   },

--- a/src/Typography/index.js
+++ b/src/Typography/index.js
@@ -7,6 +7,7 @@ type Props = {
   classes: Object,
   className: string,
   component: string,
+  gutterBottom: boolean,
   theme: Object,
   type:
     | "title"
@@ -33,6 +34,7 @@ const Typography = ({
   classes,
   className,
   component: componentProp,
+  gutterBottom,
   theme,
   type,
   ...rest
@@ -40,7 +42,12 @@ const Typography = ({
   const Element = componentProp || typeElementMap[type] || "span";
   return (
     <Element
-      className={classNames(classes.root, classes[type], className)}
+      className={classNames(
+        classes.root,
+        classes[type],
+        gutterBottom && classes.gutterBottom,
+        className
+      )}
       {...rest}
     >
       {children}
@@ -92,5 +99,8 @@ export default withStyles((theme) => ({
     maxWidth: "600px",
     fontSize: "14px",
     lineHeight: "18px",
+  },
+  gutterBottom: {
+    marginBottom: "0.35em",
   },
 }))(Typography);


### PR DESCRIPTION
## Adds 
- Documentation 
- Other heading levels other then `<h1>`
- `gutterBottom` prop that adds a `marginBottom` of `0.35em` so we can quickly add spacing.

I'd like to get feedback on this since @chrisheninger and I have talked about possibly naming the heading levels differently. I also know that Dillon was working on some styling, so there could be room for improvement there as well. 