### PR TITLE
Update withStyles to account for theme-level overrides

### DIFF
--- a/demo/src/docs/ThemeOverrides.js
+++ b/demo/src/docs/ThemeOverrides.js
@@ -1,0 +1,66 @@
+import React from "react";
+import Paper from "elevate-ui/Paper";
+import ThemeProvider from "elevate-ui/ThemeProvider";
+import Typography from "elevate-ui/Typography";
+import InputDocs from "./Input";
+
+const ThemeOverrides = () => (
+  <ThemeProvider
+    theme={{
+      colors: {
+        primary: "navy",
+      },
+      overrides: {
+        EuiButton: {
+          root: {
+            width: "100%",
+          },
+          children: {
+            fontSize: "18px",
+            padding: "14px 24px",
+          },
+        },
+        EuiInput: {
+          root: {
+            fontSize: "20px",
+            backgroundColor: "#fff",
+            borderWidth: "2px",
+            borderColor: "#232425",
+            borderRadius: "4px",
+            padding: "14px 16px",
+            height: "auto",
+          },
+        },
+        EuiLabel: {
+          root: {
+            color: "#232425",
+            fontSize: "16px",
+            marginBottom: "8px",
+          },
+        },
+        EuiValidation: {
+          root: {
+            fontSize: "16px",
+            padding: "6px 16px",
+          },
+        },
+      },
+    }}
+  >
+    <Paper style={{ marginBottom: "8px" }}>
+      <Typography type="title">Theme Overrides</Typography>
+      <Typography type="body" gutterTop gutterBottom>
+        Elevate-UI allows you to declare theme-level overrides for components.
+        For example, if you want to change the border color of every Input
+        component, you can declare it in the theme.
+      </Typography>
+      <Typography type="body" gutterTop style={{ marginBottom: "32px" }}>
+        You can nest ThemeProviders and overrides will only be applied to the
+        child component. Neat!
+      </Typography>
+    </Paper>
+    <InputDocs />
+  </ThemeProvider>
+);
+
+export default ThemeOverrides;

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -8,11 +8,7 @@ import Main from "./layout/Main";
 
 render(
   <ThemeProvider>
-    <Router
-      basename={
-        window.location.href.includes("github.io") ? "/elevate-ui" : "/"
-      }
-    >
+    <Router>
       <Main />
     </Router>
   </ThemeProvider>,

--- a/demo/src/layout/Doc.js
+++ b/demo/src/layout/Doc.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "elevate-ui/withStyles";
 import classNames from "classnames";
 
 import Paper from "elevate-ui/Paper";

--- a/demo/src/layout/Header.js
+++ b/demo/src/layout/Header.js
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "elevate-ui/withStyles";
 import { Link } from "react-router-dom";
 import Menu from "elevate-ui-icons/Menu";
 

--- a/demo/src/layout/IconDoc.js
+++ b/demo/src/layout/IconDoc.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "elevate-ui/withStyles";
 
 import LiveExample from "./LiveExample";
 import Paper from "elevate-ui/Paper";

--- a/demo/src/layout/LiveExample.js
+++ b/demo/src/layout/LiveExample.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "elevate-ui/withStyles";
 
 import Typography from "elevate-ui/Typography";
 import Paper from "elevate-ui/Paper";
@@ -73,7 +73,7 @@ class LiveExample extends Component<Props, State> {
   }
 }
 
-export default withStyles((theme) => ({
+export default withStyles(() => ({
   root: {
     display: "flex",
     position: "relative",

--- a/demo/src/layout/Main.js
+++ b/demo/src/layout/Main.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import classNames from "classnames";
 import { Route } from "react-router-dom";
-import withStyles from "react-jss";
+import withStyles from "elevate-ui/withStyles";
 import noScroll from "no-scroll";
 
 import Loadable from "elevate-ui/Loadable";
@@ -16,6 +16,9 @@ const Home = Loadable({ loader: () => import("../docs/Home") });
 const SignupForm = Loadable({ loader: () => import("../docs/SignupForm") });
 const QueryForm = Loadable({ loader: () => import("../docs/QueryForm") });
 const Theme = Loadable({ loader: () => import("../docs/Theme") });
+const ThemeOverrides = Loadable({
+  loader: () => import("../docs/ThemeOverrides"),
+});
 
 class Main extends Component {
   state = {
@@ -99,6 +102,7 @@ class Main extends Component {
             <Route path="/signup" component={SignupForm} />
             <Route path="/query-form" component={QueryForm} />
             <Route path="/theme" component={Theme} />
+            <Route path="/theme-overrides" component={ThemeOverrides} />
             <Route
               path="/accordion"
               render={() => <Doc folder="Accordion" />}
@@ -145,7 +149,7 @@ export default withStyles((theme) => ({
     flex: "1",
     display: "flex",
     flexDirection: "column",
-    justifyContent: "space-between",
+    justifyContent: "flex-start",
     alignItems: "center",
     alignSelf: "stretch",
     width: "100%",

--- a/demo/src/layout/Sidebar.js
+++ b/demo/src/layout/Sidebar.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "elevate-ui/withStyles";
 import { Link, NavLink } from "react-router-dom";
 
 const Sidebar = ({ classes }) => {
@@ -148,6 +148,13 @@ const Sidebar = ({ classes }) => {
           to="/theme"
         >
           Theme
+        </NavLink>
+        <NavLink
+          activeClassName={classes.active}
+          className={classes.item}
+          to="/theme-overrides"
+        >
+          Theme Overrides
         </NavLink>
 
         <NavLink

--- a/src/Accordion/index.js
+++ b/src/Accordion/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import ChevronRight from "elevate-ui-icons/ChevronRight";
 
 import BaseAccordion from "./BaseAccordion";

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 
 type Props = {
   /**

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import Color from "color";
 
 type Props = {

--- a/src/ButtonGroup/index.js
+++ b/src/ButtonGroup/index.js
@@ -1,5 +1,5 @@
 import React, { Component, Fragment } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import get from "lodash/get";
 

--- a/src/CheckboxGroup/index.js
+++ b/src/CheckboxGroup/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import UncontrolledCheckbox from "../Checkbox/UncontrolledCheckbox";
 import Label from "../Label";

--- a/src/Datetime/index.js
+++ b/src/Datetime/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import ReactDatetime from "react-datetime";
 import get from "lodash/get";

--- a/src/Input/SearchInput.js
+++ b/src/Input/SearchInput.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 
 type Props = {

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import get from "lodash/get";
 

--- a/src/Label/index.js
+++ b/src/Label/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 
 const Label = ({ classes, className, children, theme, ...rest }) => {

--- a/src/Loadable/FullscreenLoader.js
+++ b/src/Loadable/FullscreenLoader.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 
 /* Animated SVG thanks to @sherb at http://samherbert.net/svg-loaders/ */
 const FullscreenLoader = ({

--- a/src/MultiSelect/Tag.js
+++ b/src/MultiSelect/Tag.js
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 
 import Close from "elevate-ui-icons/Close";
 

--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component, Fragment } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import Downshift from "downshift";
 import AutosizeInput from "react-input-autosize";

--- a/src/NumberIncrement/index.js
+++ b/src/NumberIncrement/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import Remove from "elevate-ui-icons/Remove";
 import Add from "elevate-ui-icons/Add";

--- a/src/Paper/index.js
+++ b/src/Paper/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 
 type Props = {

--- a/src/RadioGroup/index.js
+++ b/src/RadioGroup/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import Radio from "./Radio";
 import Label from "../Label";

--- a/src/Scaffold/index.js
+++ b/src/Scaffold/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 
 import Label from "../Label";

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 import Downshift from "downshift";
 import get from "lodash/get";
@@ -251,7 +251,9 @@ const styles = (theme) => ({
     width: "100%",
     minHeight: "40px",
     backgroundColor: theme.colors.white,
-    border: `1px solid ${theme.colors.gray300}`,
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: theme.colors.gray300,
     padding: "0 12px",
     cursor: (props) => (props.disabled ? "not-allowed" : "default"),
   },

--- a/src/Table/ActionButtons.js
+++ b/src/Table/ActionButtons.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Button from "../Button";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 
 const ActionButtons = ({ actions, classes, selection }) => (
   <div className={classes.root}>

--- a/src/Table/Pagination.js
+++ b/src/Table/Pagination.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import classnames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import Button from "../Button";
 import ChevronLeft from "elevate-ui-icons/ChevronLeft";
 import ChevronRight from "elevate-ui-icons/ChevronRight";

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -2,7 +2,7 @@
 // https://github.com/react-tools/react-table#js-styles
 import React, { Component } from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import ReactTable from "react-table";
 
 import FilterComponent from "./FilterComponent";

--- a/src/Textarea/index.js
+++ b/src/Textarea/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import get from "lodash/get";
 
 import Scaffold from "../Scaffold";

--- a/src/ThemeProvider/index.js
+++ b/src/ThemeProvider/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles, { ThemeProvider as JSSThemeProvider } from "react-jss";
+import injectSheet, { ThemeProvider as JSSThemeProvider } from "react-jss";
 import merge from "lodash/merge";
 
 const colors = {
@@ -100,7 +100,7 @@ const defaultTheme = {
   typography,
 };
 
-const GlobalsAndReset = withStyles((theme) => ({
+const GlobalsAndReset = injectSheet((theme) => ({
   "@global": {
     /* Eric Meyer Reset v2.0 */
     /* https://meyerweb.com/eric/tools/css/reset/ */

--- a/src/Toggle/index.js
+++ b/src/Toggle/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 
 class Toggle extends Component {

--- a/src/Typography/index.js
+++ b/src/Typography/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 
 type Props = {
   children: any,

--- a/src/Validation/index.js
+++ b/src/Validation/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import withStyles from "react-jss";
+import withStyles from "../withStyles";
 import classNames from "classnames";
 
 type Props = {

--- a/src/withStyles/index.js
+++ b/src/withStyles/index.js
@@ -1,3 +1,19 @@
-import withStyles from "react-jss";
+import injectSheet from "react-jss";
+import merge from "lodash/merge";
+
+const withStyles = (styles, options) =>
+  injectSheet((theme) => {
+    if (
+      options &&
+      options.name &&
+      theme &&
+      theme.overrides &&
+      theme.overrides[options.name]
+    ) {
+      return merge(styles(theme), theme.overrides[options.name]);
+    }
+
+    return styles(theme);
+  });
 
 export default withStyles;


### PR DESCRIPTION
We can now declare style overrides for specific components from the theme-level. 🎉 

Also, you can nest ThemeProviders... so you can apply overrides within a specific tree.

Example:
```jsx
  <ThemeProvider
    theme={{
      colors: {
        primary: "navy",
      },
      overrides: {
        EuiButton: {
          root: {
            width: "100%",
          },
          children: {
            fontSize: "18px",
            padding: "14px 24px",
          },
        },
        EuiInput: {
          root: {
            fontSize: "20px",
            backgroundColor: "#fff",
            borderWidth: "2px",
            borderColor: "#232425",
            borderRadius: "4px",
            padding: "14px 16px",
            height: "auto",
          },
        },
        EuiLabel: {
          root: {
            color: "#232425",
            fontSize: "16px",
            marginBottom: "8px",
          },
        },
        EuiValidation: {
          root: {
            fontSize: "16px",
            padding: "6px 16px",
          },
        },
      },
    }}
  >
```

Default
<img width="498" alt="screen shot 2018-11-11 at 8 35 54 pm" src="https://user-images.githubusercontent.com/5051745/48325144-72297a00-e5f1-11e8-8e87-29e3551d0dd5.png">

Overrides
<img width="541" alt="screen shot 2018-11-11 at 8 36 02 pm" src="https://user-images.githubusercontent.com/5051745/48325152-79508800-e5f1-11e8-934f-28f7d7f907e1.png">
