### PR TITLE
Update color logic to test primary and secondary color values for chi…

### DIFF
--- a/demo/src/docs/Button.js
+++ b/demo/src/docs/Button.js
@@ -45,6 +45,11 @@ const ButtonExample = () => (
     </Button>
     <br />
     <br />
+    <Button color="#FDE74C" type="button">
+      White Button
+    </Button>
+    <br />
+    <br />
     <Button
       element="a"
       href="http://elevate-ui.com"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "color": "^3.0.0",
+    "color": "^3.1.0",
     "downshift": "^2.2.3",
     "elevate-ui-icons": "^0.2.0",
     "lodash": "^4.17.10",

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -85,7 +85,11 @@ function getChildColor(theme, props) {
           .string();
       }
     } else {
-      return theme.colors.white;
+      if (Color(theme.colors[props.color]).isDark()) {
+        return theme.colors.white;
+      } else {
+        return theme.colors.black;
+      }
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1546,7 +1546,7 @@ color-string@^1.5.2:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.0.0:
+color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.0.tgz#d8e9fb096732875774c84bf922815df0308d0ffc"
   integrity sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==


### PR DESCRIPTION
…ldren colors

Fixes button Children color logic to evaluate the actual color value of theme provided colors. It's worth noting that while this isn't a "breaking" change, visually you could call it breaking. For instance, primary buttons in elevate red color now have dark text on them instead of white. 

![screen shot 2019-02-07 at 4 48 13 pm](https://user-images.githubusercontent.com/9441913/52450595-fad48b00-2af8-11e9-8d57-148d4c6d18d4.png)
