### PR TITLE
If no value for datetime exists set to null

### DIFF
--- a/src/Datetime/index.js
+++ b/src/Datetime/index.js
@@ -53,7 +53,7 @@ const Datetime = ({
       <div className={classNames(classes.root, className)}>
         <ReactDatePicker
           name={name}
-          selected={value || new Date()}
+          selected={value || null}
           timeFormat="h:mma"
           timeCaption="Time"
           locale="en"


### PR DESCRIPTION
This sets the datetime picker to no date if one is not supplied instead of selecting the current day. 